### PR TITLE
Update action to support v2 of the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **Learn more about zeroheight's design system adoption features, such as [component usage tracking](https://zeroheight.com/help/article/component-usage/) and [package monitoring](https://zeroheight.com/help/article/package-version-monitoring/), in [our learning hub](https://zeroheight.com/help/article/adoption-private-beta-overview/#experimental-features) or check out the linked video below.**
 
-[<img src="https://img.youtube.com/vi/U7Lp2iVIs7k/maxresdefault.jpg" width="100%" alt="YouTube video" />](https://youtu.be/U7Lp2iVIs7k)
+[<img src="https://img.youtube.com/vi/U7Lp2iVIs7k/maxresdefault.jpg" width="100%" alt="YouTube video"/>](https://youtu.be/U7Lp2iVIs7k)
 
 ---
 
@@ -27,17 +27,37 @@
 > This action presumes you already have a zeroheight account. You can [sign up here](https://zeroheight.com/create/account?utm_department=marketing&utm_source=github).
 
 1. Head to [`zeroheight.com/adoption`](https://zeroheight.com/adoption) and follow the steps to connect your design system packages and application source code to zeroheight
-3. Use the component tracking setup steps to create a Client ID and Access Token and ensure to note these down for future use
+3. Follow the "Use the CLI" flow to create a Client ID and Access Token and ensure to note these down for future use
 4. Now head over to your application's source code on GitHub and enter your zeroheight Client ID and Access Token as GitHub repository secrets (Settings → Secrets and variables → Actions) using `ZEROHEIGHT_CLIENT_ID` and `ZEROHEIGHT_ACCESS_TOKEN` respectively
-5. Once complete, add the following step to your existing GitHub Action workflow file:
-   ```yaml
-      - name: Analyze design system adoption data
-        uses: zh-ski/action-design-system-adoption@v1
-        env:
-          ZEROHEIGHT_CLIENT_ID: "${{ secrets.ZEROHEIGHT_CLIENT_ID }}"
-          ZEROHEIGHT_ACCESS_TOKEN: "${{ secrets.ZEROHEIGHT_ACCESS_TOKEN }}"
-   ```
-   We recommend adding it as part of your post-deployment workflows. If you're new to workflows and actions check out [GitHub's Actions documentation](https://docs.github.com/en/actions) for more info.
-6. Save your changes, trigger your action, and check in zeroheight to see design system usage data come in 🎉
+5. Once completed you can use the action as part of your GitHub Action workflow file
+
+## Usage
+
+```yaml
+  - name: Analyze design system adoption data
+    uses: zh-ski/action-design-system-adoption@v2
+    with:
+      command: 'analyze' # or track-package, monitor-repo
+      arguments: '--ignore "**/*.spec.*"' # optionally supply additional arguments
+    env:
+      ZEROHEIGHT_CLIENT_ID: "${{ secrets.ZEROHEIGHT_CLIENT_ID }}"
+      ZEROHEIGHT_ACCESS_TOKEN: "${{ secrets.ZEROHEIGHT_ACCESS_TOKEN }}"
+```
+
+We recommend adding it as part of your post-deployment workflows. If you're new to workflows and actions check out [GitHub's Actions documentation](https://docs.github.com/en/actions) for more info.
+
+### Inputs
+
+* `command` - The CLI command to run, can be one of `analyze`, `track-package` or `monitor-repo`
+* `arguments` - Optionally provide additional arguments to pass to the command
+
+### Environment Variables
+
+* `ZEROHEIGHT_CLIENT_ID` - Client ID for the authentication token generated in zeroheight
+* `ZEROHEIGHT_ACCESS_TOKEN` - Access Token for the authentication token generated in zeroheight
+
+See the [CLI documentation](https://www.npmjs.com/package/@zeroheight/adoption-cli) for more details on the commands and arguments
+
+## Example
 
 **Check out [our example React application](https://github.com/zeroheight-demos/example-airorange-app) for reference and [it's containing GitHub Action file](https://github.com/zeroheight-demos/example-airorange-app/blob/master/.github/workflows/deploy.yaml).**

--- a/README.md
+++ b/README.md
@@ -30,15 +30,30 @@
 3. Follow the "Use the CLI" flow to create a Client ID and Access Token and ensure to note these down for future use
 4. Now head over to your application's source code on GitHub and enter your zeroheight Client ID and Access Token as GitHub repository secrets (Settings → Secrets and variables → Actions) using `ZEROHEIGHT_CLIENT_ID` and `ZEROHEIGHT_ACCESS_TOKEN` respectively
 5. Once completed you can use the action as part of your GitHub Action workflow file
+6. Once your workflow is updated, trigger your action, and check in zeroheight to see design system usage data come in 🎉
 
 ## Usage
+
+### Basic usage
 
 ```yaml
   - name: Analyze design system adoption data
     uses: zh-ski/action-design-system-adoption@v2
     with:
-      command: 'analyze' # or track-package, monitor-repo
-      arguments: '--ignore "**/*.spec.*"' # optionally supply additional arguments
+      command: 'track-package'
+    env:
+      ZEROHEIGHT_CLIENT_ID: "${{ secrets.ZEROHEIGHT_CLIENT_ID }}"
+      ZEROHEIGHT_ACCESS_TOKEN: "${{ secrets.ZEROHEIGHT_ACCESS_TOKEN }}"
+```
+
+### Supplying additional arguments
+
+```yaml
+  - name: Track package version
+    uses: zh-ski/action-design-system-adoption@v2
+    with:
+      command: 'analyze'
+      arguments: '--ignore "**/*.spec.*'
     env:
       ZEROHEIGHT_CLIENT_ID: "${{ secrets.ZEROHEIGHT_CLIENT_ID }}"
       ZEROHEIGHT_ACCESS_TOKEN: "${{ secrets.ZEROHEIGHT_ACCESS_TOKEN }}"

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,20 @@ branding:
   icon: 'bar-chart'
   color: 'purple'
 
+inputs:
+  command:
+    description: 'The command to run'
+    required: true
+    type: choice
+    options:
+      - 'analyze'
+      - 'track-package'
+      - 'monitor-repo'
+  arguments:
+    description: 'Additional arguments to pass to the command'
+    required: false
+    type: string
+
 runs:
   using: 'composite'
   steps:
@@ -12,8 +26,21 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: 20
+
     - name: Checkout code
       uses: actions/checkout@v3
+
     - name: Analyze and update
-      run: npx @zeroheight/adoption-cli analyze --interactive false --repo-name ${{ github.event.repository.name }}
+      if: ${{ inputs.command == 'analyze' }}
+      run: npx @zeroheight/adoption-cli analyze --interactive false --repo-name ${{ github.event.repository.name }} ${{ inputs.arguments }}
+      shell: bash
+
+    - name: Track package
+      if: ${{ inputs.command == 'track-package' }}
+      run: npx @zeroheight/adoption-cli track-package --interactive false ${{ inputs.arguments }}
+      shell: bash
+
+    - name: Monitor repo
+      if: ${{ inputs.command == 'monitor-repo' }}
+      run: npx @zeroheight/adoption-cli monitor-repo ${{ inputs.arguments }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
       - 'analyze'
       - 'track-package'
       - 'monitor-repo'
+
   arguments:
     description: 'Additional arguments to pass to the command'
     required: false
@@ -22,6 +23,20 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate command
+      run: |
+        # if command is blank
+        if [[ -z "${{ inputs.command }}" ]]; then
+          echo "::error::Command is required"
+          exit 1
+        fi
+
+        if [[ ! "${{ inputs.command }}" =~ ^(analyze|track-package|monitor-repo)$ ]]; then
+          echo "::error::Invalid command. Must be one of: analyze, track-package, monitor-repo"
+          exit 1
+        fi
+      shell: bash
+
     - name: Setup Node
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## Context

The [zeroheight adoption CLI](https://www.npmjs.com/package/@zeroheight/adoption-cli) has been updated with `track-package` and `monitor-repo` commands that are intended to be used as part of CI workflows

## Changes

The action has been updated to have 2 new inputs:
* `command` - allows users to specify what command in the CLI they would like to run
* `arguments` - allows users to optionally provide additional arguments to use with the command

README has been updated to document the inputs and environment variables