### PR TITLE
Add missing quote to readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
     uses: zeroheight/action-design-system-adoption@v2
     with:
       command: 'analyze'
-      arguments: '--ignore "**/*.spec.*'
+      arguments: '--ignore "**/*.spec.*"'
     env:
       ZEROHEIGHT_CLIENT_ID: "${{ secrets.ZEROHEIGHT_CLIENT_ID }}"
       ZEROHEIGHT_ACCESS_TOKEN: "${{ secrets.ZEROHEIGHT_ACCESS_TOKEN }}"


### PR DESCRIPTION
There was a quote missing in one of the examples

Related issue: #5 